### PR TITLE
FISH-6025: Fix state incosistencies

### DIFF
--- a/grpc-support/src/main/java/fish/payara/extension/grpc/servlet/ServletAdapter.java
+++ b/grpc-support/src/main/java/fish/payara/extension/grpc/servlet/ServletAdapter.java
@@ -291,7 +291,7 @@ public final class ServletAdapter {
     public void onAllDataRead() {
       logger.log(FINE, "[{0}] onAllDataRead", logId);
       stream.transportState().runOnTransportThread(() ->
-          stream.transportState().inboundDataReceived(ReadableBuffers.wrap(new byte[] {}), true));
+          stream.transportState().inboundDataReceived(ReadableBuffers.empty(), true));
     }
 
     @Override

--- a/grpc-support/src/main/java/fish/payara/extension/grpc/servlet/ServletServerStream.java
+++ b/grpc-support/src/main/java/fish/payara/extension/grpc/servlet/ServletServerStream.java
@@ -134,17 +134,14 @@ final class ServletServerStream extends AbstractServerStream {
 
   final class ServletTransportState extends TransportState {
 
-    private final SerializingExecutor transportThreadExecutor =
-        new SerializingExecutor(Executors.newSingleThreadExecutor());
-
     private ServletTransportState(
         int maxMessageSize, StatsTraceContext statsTraceCtx, TransportTracer transportTracer) {
       super(maxMessageSize, statsTraceCtx, transportTracer);
     }
 
     @Override
-    public void runOnTransportThread(Runnable r) {
-      transportThreadExecutor.execute(r);
+    public synchronized void runOnTransportThread(Runnable r) {
+      r.run();
     }
 
     @Override


### PR DESCRIPTION
Response should not be touched after asyncContext is completed.

Thread per request for synchronizing data exchange is not necessary in servlet environment and may hurt performance.