### PR TITLE
FISH-12017: gRPC Support for Payara Enterprise 7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,28 +6,16 @@ pipeline {
         label 'general-purpose'
     }
     tools {
-        jdk "zulu-11"
+        jdk "zulu-21"
         maven "maven-3.6.3"
     }
     environment {
-        JAVA_HOME = tool("zulu-11")
+        JAVA_HOME = tool("zulu-21")
         MAVEN_OPTS = '-Xmx2G -Djavax.net.ssl.trustStore=${JAVA_HOME}/jre/lib/security/cacerts'
         payaraBuildNumber = "${BUILD_NUMBER}"
     }
     stages {
 
-        stage('Checkout Payara6') {
-            steps {
-                script {
-                    checkout changelog: false, poll: true, scm: [$class: 'GitSCM',
-                    branches: [[name: "Payara6"]],
-                    doGenerateSubmoduleConfigurations: false,
-                    extensions: [], 
-                    submoduleCfg: [],
-                    userRemoteConfigs: [[credentialsId: 'payara-devops-github-personal-access-token-as-username-password', url:"https://github.com/payara/gRPC.git"]]]
-                }
-            }
-        }
         stage('Build') {
             steps {
                 script {

--- a/grpc-support/pom.xml
+++ b/grpc-support/pom.xml
@@ -12,8 +12,8 @@
     <artifactId>grpc-support</artifactId>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <licenses>
@@ -33,7 +33,7 @@
         </dependency>
         <!-- server internals -->
         <dependency>
-            <groupId>fish.payara.server.internal.common</groupId>
+            <groupId>fish.payara.server.core.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${payara.internal.version}</version>
             <scope>provided</scope>
@@ -136,13 +136,13 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.internal.common</groupId>
+            <groupId>fish.payara.server.core.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${payara.internal.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.internal.deployment</groupId>
+            <groupId>fish.payara.server.core.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${payara.internal.version}</version>
             <scope>provided</scope>
@@ -153,7 +153,7 @@
             <plugin>
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>hk2-inhabitant-generator</artifactId>
-                <version>3.0.2</version>
+                <version>4.0.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -165,7 +165,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.4</version>
+                <version>6.0.2</version>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>

--- a/grpc-support/src/main/java/fish/payara/extension/grpc/servlet/ServletServerStream.java
+++ b/grpc-support/src/main/java/fish/payara/extension/grpc/servlet/ServletServerStream.java
@@ -49,9 +49,7 @@ import static io.grpc.internal.GrpcUtil.CONTENT_TYPE_GRPC;
 import static io.grpc.internal.GrpcUtil.CONTENT_TYPE_KEY;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static java.util.Arrays.copyOfRange;
-
-import static jakarta.xml.bind.DatatypeConverter.printHexBinary;
+import java.util.HexFormat;
 
 final class ServletServerStream extends AbstractServerStream {
 
@@ -321,14 +319,16 @@ final class ServletServerStream extends AbstractServerStream {
     }
   }
 
+  private static final HexFormat HEX = HexFormat.of().withUpperCase();
+
   static String toHexString(byte[] bytes, int length) {
-    String hex = printHexBinary(copyOfRange(bytes, 0, min(length, 64)));
+    String hex = HEX.formatHex(bytes, 0, min(length, 64));
     if (length > 80) {
       hex += "...";
     }
     if (length > 64) {
       int offset = max(64, length - 16);
-      hex += printHexBinary(copyOfRange(bytes, offset, length));
+      hex += HEX.formatHex(bytes, offset, Math.min(length, bytes.length));
     }
     return hex;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,8 @@
         <grpc.version>1.45.0</grpc.version>
         <protobuf.version>3.19.4</protobuf.version>
         <payara.version>7.2026.5</payara.version>
-        <payara.internal.version>7.0.0.Alpha1</payara.internal.version>
+        <payara-nexus-staging.repo.releases.enabled>false</payara-nexus-staging.repo.releases.enabled>
+        <payara-nexus-staging.repo.snapshots.enabled>false</payara-nexus-staging.repo.snapshots.enabled>
     </properties>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -53,13 +53,13 @@
     <version>1.0.0</version>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <grpc.version>1.45.0</grpc.version>
         <protobuf.version>3.19.4</protobuf.version>
-        <payara.version>6.2022.1.Alpha4</payara.version>
-        <payara.internal.version>6.2022.1.Alpha4</payara.internal.version>
+        <payara.version>7.2026.5</payara.version>
+        <payara.internal.version>7.0.0.Alpha1</payara.internal.version>
     </properties>
 
     <licenses>
@@ -97,32 +97,37 @@
         </dependencies>
     </dependencyManagement>
 
-    <repositories>
-        <repository>
-            <id>payara-nexus-artifacts</id>
-            <name>Payara Nexus Artifacts</name>
-            <url>https://nexus.payara.fish/repository/payara-artifacts/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>payara-nexus-community</id>
-            <name>Payara Nexus Community</name>
-            <url>https://nexus.payara.fish/repository/payara-community/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <modules>
         <module>grpc-support</module>
     </modules>
+
+    <repositories>
+        <repository>
+            <id>payara-nexus-artifacts</id>
+            <url>https://nexus.payara.fish/repository/payara-artifacts/</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+        <repository>
+            <id>payara-nexus-community</id>
+            <url>https://nexus.payara.fish/repository/payara-community/</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>payara-nexus-artifacts</id>
+            <url>https://nexus.payara.fish/repository/payara-artifacts/</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>payara-nexus-community</id>
+            <url>https://nexus.payara.fish/repository/payara-community/</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -102,32 +102,144 @@
     </modules>
 
     <repositories>
+        <!-- Try Maven central first, not last, which happens when omitted here -->
         <repository>
-            <id>payara-nexus-artifacts</id>
-            <url>https://nexus.payara.fish/repository/payara-artifacts/</url>
-            <releases><enabled>true</enabled></releases>
-            <snapshots><enabled>false</enabled></snapshots>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
         <repository>
-            <id>payara-nexus-community</id>
-            <url>https://nexus.payara.fish/repository/payara-community/</url>
-            <releases><enabled>true</enabled></releases>
-            <snapshots><enabled>false</enabled></snapshots>
+            <id>ossrh-snapshots</id>
+            <name>Sonatype OSSRH Snapshot Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>payara-nexus-artifacts</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-artifacts</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>payara-nexus-enterprise-artifacts</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-enterprise-artifacts-private</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>payara-nexus-enterprise-distributions</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-enterprise</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>payara-nexus-enterprise-snapshots</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-enterprise-snapshots-private</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>payara-nexus-snapshots</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>payara-nexus-staging</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-staging</url>
+            <releases>
+                <enabled>${payara-nexus-staging.repo.releases.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${payara-nexus-staging.repo.snapshots.enabled}</enabled>
+            </snapshots>
         </repository>
     </repositories>
 
     <pluginRepositories>
+        <!-- Try Maven central first, not last, which happens when omitted here -->
         <pluginRepository>
-            <id>payara-nexus-artifacts</id>
-            <url>https://nexus.payara.fish/repository/payara-artifacts/</url>
-            <releases><enabled>true</enabled></releases>
-            <snapshots><enabled>false</enabled></snapshots>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </pluginRepository>
         <pluginRepository>
-            <id>payara-nexus-community</id>
-            <url>https://nexus.payara.fish/repository/payara-community/</url>
-            <releases><enabled>true</enabled></releases>
-            <snapshots><enabled>false</enabled></snapshots>
+            <id>ossrh-snapshots</id>
+            <name>Sonatype OSSRH Snapshot Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>payara-nexus-artifacts</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-artifacts</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>payara-nexus-snapshots</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>payara-nexus-staging</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-staging</url>
+            <releases>
+                <enabled>${payara-nexus-staging.repo.releases.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${payara-nexus-staging.repo.snapshots.enabled}</enabled>
+            </snapshots>
         </pluginRepository>
     </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <grpc.version>1.45.0</grpc.version>
         <protobuf.version>3.19.4</protobuf.version>
-        <payara.version>6.2022.1.Alpha2</payara.version>
-        <payara.internal.version>6.2022.1.Alpha2</payara.internal.version>
+        <payara.version>6.2022.1.Alpha4</payara.version>
+        <payara.internal.version>6.2022.1.Alpha4</payara.internal.version>
     </properties>
 
     <licenses>
@@ -96,6 +96,31 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <repositories>
+        <repository>
+            <id>payara-nexus-artifacts</id>
+            <name>Payara Nexus Artifacts</name>
+            <url>https://nexus.payara.fish/repository/payara-artifacts/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>payara-nexus-community</id>
+            <name>Payara Nexus Community</name>
+            <url>https://nexus.payara.fish/repository/payara-community/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <modules>
         <module>grpc-support</module>


### PR DESCRIPTION
- Updated compiler targets, Payara versions, and the `hk2-inhabitant-generator` plugin across both POMs for Payara 7 / Java 21
- Replaced a deprecated `jakarta.xml.bind.DatatypeConverter` call with `java.util.HexFormat` (Java 17+) to remove the unnecessary JAXB dependency
- Upgraded `maven-bundle-plugin` from `5.1.4` to `6.0.2` 

Overall it is working fine, to test it out, Use [gRPC Example](https://github.com/payara/Payara-Examples/tree/main/grpc).
(Before using the gRPC example, upgrade it to 21 and jakarta 10.x version.)

Docs are updated here: https://github.com/payara/Payara-Documentation/pull/806

<img width="1214" height="280" alt="image" src="https://github.com/user-attachments/assets/19ef4ab1-a74e-4734-b338-18b8a359df96" />

