### PR TITLE
FISH-12017: Fixed version and repo for Payara 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <grpc.version>1.45.0</grpc.version>
         <protobuf.version>3.19.4</protobuf.version>
-        <payara.version>6.2022.1.Alpha2</payara.version>
-        <payara.internal.version>6.2022.1.Alpha2</payara.internal.version>
+        <payara.version>6.2022.1.Alpha4</payara.version>
+        <payara.internal.version>6.2022.1.Alpha4</payara.internal.version>
     </properties>
 
     <licenses>
@@ -96,6 +96,31 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <repositories>
+        <repository>
+            <id>payara-nexus-artifacts</id>
+            <name>Payara Nexus Artifacts</name>
+            <url>https://nexus.payara.fish/repository/payara-artifacts/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>payara-nexus-community</id>
+            <name>Payara Nexus Community</name>
+            <url>https://nexus.payara.fish/repository/payara-community/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <modules>
         <module>grpc-support</module>


### PR DESCRIPTION
Payara 6 artifacts are move from maven to payara nexus and also the version is discarded so need to update repo and version. Payara7 branch cut from Payara 6.

Also need to be fixed in Payara6 branch.